### PR TITLE
ath10k-firmware: update Candela Tech firmware images

### DIFF
--- a/package/firmware/ath10k-firmware/Makefile
+++ b/package/firmware/ath10k-firmware/Makefile
@@ -94,62 +94,62 @@ endef
 $(eval $(call Download,ath10k-firmware-qca9887-ct-htt))
 
 
-QCA99X0_FIRMWARE_FILE_CT:=firmware-5-ct-full-community-12.bin-lede.002
+QCA99X0_FIRMWARE_FILE_CT:=firmware-5-ct-full-community-12.bin-lede.003
 define Download/ath10k-firmware-qca99x0-ct
   $(call Download/ct-firmware,QCA99X0,ath10k-10-4b)
-  HASH:=1d4fd0c05368efbaa987e903c1f9c88eb594e23db93e36869f9d5016734996d4
+  HASH:=6685623e2ee75909f734e45ae9321b9f78b18ed8c585eadef88f951b8aa4b3be
 endef
 $(eval $(call Download,ath10k-firmware-qca99x0-ct))
 
-QCA99X0_FIRMWARE_FILE_CT_HTT:=firmware-5-ct-full-htt-mgt-community-12.bin-lede.002
+QCA99X0_FIRMWARE_FILE_CT_HTT:=firmware-5-ct-full-htt-mgt-community-12.bin-lede.003
 define Download/ath10k-firmware-qca99x0-ct-htt
   $(call Download/ct-firmware-htt,QCA99X0,ath10k-10-4b)
-  HASH:=435877ebba90224fe3b696c1c459da281230f527ea05c316b7eeceb1a13b5e19
+  HASH:=ea5ccdc88a1371e958b4b5e7657782b1bcc55ac24e11e6fa36a3fce2746be4d6
 endef
 $(eval $(call Download,ath10k-firmware-qca99x0-ct-htt))
 
 
-QCA9984_FIRMWARE_FILE_CT:=firmware-5-ct-full-community-12.bin-lede.002
+QCA9984_FIRMWARE_FILE_CT:=firmware-5-ct-full-community-12.bin-lede.003
 define Download/ath10k-firmware-qca9984-ct
   $(call Download/ct-firmware,QCA9984,ath10k-9984-10-4b)
-  HASH:=b9bbb25f5f6753ca46aeaaf93b6b8d84354b38ef292e4ea6255c627edfb00ad7
+  HASH:=0815fffb4757596a5ee41efb8353fb90667e4c26363fbd62a5ccf269e9a55938
 endef
 $(eval $(call Download,ath10k-firmware-qca9984-ct))
 
-QCA9984_FIRMWARE_FILE_CT_HTT:=firmware-5-ct-full-htt-mgt-community-12.bin-lede.002
+QCA9984_FIRMWARE_FILE_CT_HTT:=firmware-5-ct-full-htt-mgt-community-12.bin-lede.003
 define Download/ath10k-firmware-qca9984-ct-htt
   $(call Download/ct-firmware-htt,QCA9984,ath10k-9984-10-4b)
-  HASH:=15fd6aa58e5bf96bf7232c739c97598b4573bb514974a8969a8fe21eb3015356
+  HASH:=425b66e51039f1970802940c864ad3d6b743926e310006f6601acb9689144315
 endef
 $(eval $(call Download,ath10k-firmware-qca9984-ct-htt))
 
 
-QCA4019_FIRMWARE_FILE_CT:=firmware-5-ct-full-community-12.bin-lede.002
+QCA4019_FIRMWARE_FILE_CT:=firmware-5-ct-full-community-12.bin-lede.003
 define Download/ath10k-firmware-qca4019-ct
   $(call Download/ct-firmware,QCA4019,ath10k-4019-10-4b)
-  HASH:=6ba3a1b883d65546353f4a9246f7e5327922c7c9dfd472c71926737d94cff2db
+  HASH:=6e9171d012b50053b04572933b619927070b95fd2d8b9274a3e59a374088a09d
 endef
 $(eval $(call Download,ath10k-firmware-qca4019-ct))
 
-QCA4019_FIRMWARE_FILE_CT_HTT:=firmware-5-ct-full-htt-mgt-community-12.bin-lede.002
+QCA4019_FIRMWARE_FILE_CT_HTT:=firmware-5-ct-full-htt-mgt-community-12.bin-lede.003
 define Download/ath10k-firmware-qca4019-ct-htt
   $(call Download/ct-firmware-htt,QCA4019,ath10k-4019-10-4b)
-  HASH:=fe0d0a32d2f04885ec613b2af0402e8b80783fb165265ded988524e8914af0b2
+  HASH:=b265428fadda7e3ac33ef977ba1a13788914689110275e57bba7796c583f8480
 endef
 $(eval $(call Download,ath10k-firmware-qca4019-ct-htt))
 
 
-QCA9888_FIRMWARE_FILE_CT:=firmware-5-ct-full-community-12.bin-lede.002
+QCA9888_FIRMWARE_FILE_CT:=firmware-5-ct-full-community-12.bin-lede.003
 define Download/ath10k-firmware-qca9888-ct
   $(call Download/ct-firmware,QCA9888,ath10k-9888-10-4b)
-  HASH:=46e5bc1e2b3e13f48ef1d81a0927a6053bda1ef18a2acad93da5cc992ffc3e36
+  HASH:=fba3ce709cd0e17abec260639034bc99b0157f36c044713201cff2e5b408a6e2
 endef
 $(eval $(call Download,ath10k-firmware-qca9888-ct))
 
-QCA9888_FIRMWARE_FILE_CT_HTT:=firmware-5-ct-full-htt-mgt-community-12.bin-lede.002
+QCA9888_FIRMWARE_FILE_CT_HTT:=firmware-5-ct-full-htt-mgt-community-12.bin-lede.003
 define Download/ath10k-firmware-qca9888-ct-htt
   $(call Download/ct-firmware-htt,QCA9888,ath10k-9888-10-4b)
-  HASH:=7a5f3ef4e906549c3e4cd6e6f4e4c68d777206ed7c9f870c0b2d68b59928883e
+  HASH:=943c0ec1967a41f16e27fd1dfebefc9196412d48d4deba204b157bd7b9b90512
 endef
 $(eval $(call Download,ath10k-firmware-qca9888-ct-htt))
 

--- a/toolchain/gcc/patches/5.5.0/050-libitm-Don-t-redefine-__always_inline-in-local_atomi.patch
+++ b/toolchain/gcc/patches/5.5.0/050-libitm-Don-t-redefine-__always_inline-in-local_atomi.patch
@@ -1,0 +1,1092 @@
+From 55f12fce4ccf77513644a247f9c401a5b1fa2402 Mon Sep 17 00:00:00 2001
+From: torvald <torvald@138bc75d-0d04-0410-961f-82ee72b054a4>
+Date: Thu, 20 Aug 2015 17:55:24 +0000
+Subject: [PATCH] libitm: Don't redefine __always_inline in local_atomic.
+
+git-svn-id: svn+ssh://gcc.gnu.org/svn/gcc/trunk@227040 138bc75d-0d04-0410-961f-82ee72b054a4
+---
+ libitm/ChangeLog    |   6 +
+ libitm/local_atomic | 299 ++++++++++++++++++++++----------------------
+ 2 files changed, 155 insertions(+), 150 deletions(-)
+
+diff --git a/libitm/ChangeLog b/libitm/ChangeLog
+index 569d5bbbf14..6285c85fd44 100644
+--- a/libitm/ChangeLog
++++ b/libitm/ChangeLog
+@@ -1,3 +1,9 @@
++2015-08-20  Gleb Fotengauer-Malinovskiy  <glebfm@altlinux.org>  (tiny change)
++
++	PR libitm/61164
++	* local_atomic (__always_inline): Rename to...
++	(__libitm_always_inline): ... this.
++
+ 2017-10-10  Release Manager
+ 
+ 	PR target/52482
+diff --git a/libitm/local_atomic b/libitm/local_atomic
+index 3119be40d09..e536275dc9f 100644
+--- a/libitm/local_atomic
++++ b/libitm/local_atomic
+@@ -41,8 +41,7 @@
+ #ifndef _GLIBCXX_ATOMIC
+ #define _GLIBCXX_ATOMIC 1
+ 
+-#undef  __always_inline
+-#define __always_inline __attribute__((always_inline))
++#define __libitm_always_inline __attribute__((always_inline))
+ 
+ // #pragma GCC system_header
+ 
+@@ -74,7 +73,7 @@ namespace std // _GLIBCXX_VISIBILITY(default)
+       memory_order_seq_cst
+     } memory_order;
+ 
+-  inline __always_inline memory_order
++  inline __libitm_always_inline memory_order
+   __calculate_memory_order(memory_order __m) noexcept
+   {
+     const bool __cond1 = __m == memory_order_release;
+@@ -84,13 +83,13 @@ namespace std // _GLIBCXX_VISIBILITY(default)
+     return __mo2;
+   }
+ 
+-  inline __always_inline void
++  inline __libitm_always_inline void
+   atomic_thread_fence(memory_order __m) noexcept
+   {
+     __atomic_thread_fence (__m);
+   }
+ 
+-  inline __always_inline void
++  inline __libitm_always_inline void
+   atomic_signal_fence(memory_order __m) noexcept
+   {
+     __atomic_thread_fence (__m);
+@@ -280,19 +279,19 @@ namespace std // _GLIBCXX_VISIBILITY(default)
+     // Conversion to ATOMIC_FLAG_INIT.
+     atomic_flag(bool __i) noexcept : __atomic_flag_base({ __i }) { }
+ 
+-    __always_inline bool
++    __libitm_always_inline bool
+     test_and_set(memory_order __m = memory_order_seq_cst) noexcept
+     {
+       return __atomic_test_and_set (&_M_i, __m);
+     }
+ 
+-    __always_inline bool
++    __libitm_always_inline bool
+     test_and_set(memory_order __m = memory_order_seq_cst) volatile noexcept
+     {
+       return __atomic_test_and_set (&_M_i, __m);
+     }
+ 
+-    __always_inline void
++    __libitm_always_inline void
+     clear(memory_order __m = memory_order_seq_cst) noexcept
+     {
+       // __glibcxx_assert(__m != memory_order_consume);
+@@ -302,7 +301,7 @@ namespace std // _GLIBCXX_VISIBILITY(default)
+       __atomic_clear (&_M_i, __m);
+     }
+ 
+-    __always_inline void
++    __libitm_always_inline void
+     clear(memory_order __m = memory_order_seq_cst) volatile noexcept
+     {
+       // __glibcxx_assert(__m != memory_order_consume);
+@@ -455,7 +454,7 @@ namespace std // _GLIBCXX_VISIBILITY(default)
+       is_lock_free() const volatile noexcept
+       { return __atomic_is_lock_free (sizeof (_M_i), &_M_i); }
+ 
+-      __always_inline void
++      __libitm_always_inline void
+       store(__int_type __i, memory_order __m = memory_order_seq_cst) noexcept
+       {
+ 	// __glibcxx_assert(__m != memory_order_acquire);
+@@ -465,7 +464,7 @@ namespace std // _GLIBCXX_VISIBILITY(default)
+ 	__atomic_store_n(&_M_i, __i, __m);
+       }
+ 
+-      __always_inline void
++      __libitm_always_inline void
+       store(__int_type __i,
+ 	    memory_order __m = memory_order_seq_cst) volatile noexcept
+       {
+@@ -476,7 +475,7 @@ namespace std // _GLIBCXX_VISIBILITY(default)
+ 	__atomic_store_n(&_M_i, __i, __m);
+       }
+ 
+-      __always_inline __int_type
++      __libitm_always_inline __int_type
+       load(memory_order __m = memory_order_seq_cst) const noexcept
+       {
+ 	// __glibcxx_assert(__m != memory_order_release);
+@@ -485,7 +484,7 @@ namespace std // _GLIBCXX_VISIBILITY(default)
+ 	return __atomic_load_n(&_M_i, __m);
+       }
+ 
+-      __always_inline __int_type
++      __libitm_always_inline __int_type
+       load(memory_order __m = memory_order_seq_cst) const volatile noexcept
+       {
+ 	// __glibcxx_assert(__m != memory_order_release);
+@@ -494,21 +493,21 @@ namespace std // _GLIBCXX_VISIBILITY(default)
+ 	return __atomic_load_n(&_M_i, __m);
+       }
+ 
+-      __always_inline __int_type
++      __libitm_always_inline __int_type
+       exchange(__int_type __i,
+ 	       memory_order __m = memory_order_seq_cst) noexcept
+       {
+ 	return __atomic_exchange_n(&_M_i, __i, __m);
+       }
+ 
+-      __always_inline __int_type
++      __libitm_always_inline __int_type
+       exchange(__int_type __i,
+ 	       memory_order __m = memory_order_seq_cst) volatile noexcept
+       {
+ 	return __atomic_exchange_n(&_M_i, __i, __m);
+       }
+ 
+-      __always_inline bool
++      __libitm_always_inline bool
+       compare_exchange_weak(__int_type& __i1, __int_type __i2,
+ 			    memory_order __m1, memory_order __m2) noexcept
+       {
+@@ -519,7 +518,7 @@ namespace std // _GLIBCXX_VISIBILITY(default)
+ 	return __atomic_compare_exchange_n(&_M_i, &__i1, __i2, 1, __m1, __m2);
+       }
+ 
+-      __always_inline bool
++      __libitm_always_inline bool
+       compare_exchange_weak(__int_type& __i1, __int_type __i2,
+ 			    memory_order __m1,
+ 			    memory_order __m2) volatile noexcept
+@@ -531,7 +530,7 @@ namespace std // _GLIBCXX_VISIBILITY(default)
+ 	return __atomic_compare_exchange_n(&_M_i, &__i1, __i2, 1, __m1, __m2);
+       }
+ 
+-      __always_inline bool
++      __libitm_always_inline bool
+       compare_exchange_weak(__int_type& __i1, __int_type __i2,
+ 			    memory_order __m = memory_order_seq_cst) noexcept
+       {
+@@ -539,7 +538,7 @@ namespace std // _GLIBCXX_VISIBILITY(default)
+ 				     __calculate_memory_order(__m));
+       }
+ 
+-      __always_inline bool
++      __libitm_always_inline bool
+       compare_exchange_weak(__int_type& __i1, __int_type __i2,
+ 		   memory_order __m = memory_order_seq_cst) volatile noexcept
+       {
+@@ -547,7 +546,7 @@ namespace std // _GLIBCXX_VISIBILITY(default)
+ 				     __calculate_memory_order(__m));
+       }
+ 
+-      __always_inline bool
++      __libitm_always_inline bool
+       compare_exchange_strong(__int_type& __i1, __int_type __i2,
+ 			      memory_order __m1, memory_order __m2) noexcept
+       {
+@@ -558,7 +557,7 @@ namespace std // _GLIBCXX_VISIBILITY(default)
+ 	return __atomic_compare_exchange_n(&_M_i, &__i1, __i2, 0, __m1, __m2);
+       }
+ 
+-      __always_inline bool
++      __libitm_always_inline bool
+       compare_exchange_strong(__int_type& __i1, __int_type __i2,
+ 			      memory_order __m1,
+ 			      memory_order __m2) volatile noexcept
+@@ -570,7 +569,7 @@ namespace std // _GLIBCXX_VISIBILITY(default)
+ 	return __atomic_compare_exchange_n(&_M_i, &__i1, __i2, 0, __m1, __m2);
+       }
+ 
+-      __always_inline bool
++      __libitm_always_inline bool
+       compare_exchange_strong(__int_type& __i1, __int_type __i2,
+ 			      memory_order __m = memory_order_seq_cst) noexcept
+       {
+@@ -578,7 +577,7 @@ namespace std // _GLIBCXX_VISIBILITY(default)
+ 				       __calculate_memory_order(__m));
+       }
+ 
+-      __always_inline bool
++      __libitm_always_inline bool
+       compare_exchange_strong(__int_type& __i1, __int_type __i2,
+ 		 memory_order __m = memory_order_seq_cst) volatile noexcept
+       {
+@@ -586,52 +585,52 @@ namespace std // _GLIBCXX_VISIBILITY(default)
+ 				       __calculate_memory_order(__m));
+       }
+ 
+-      __always_inline __int_type
++      __libitm_always_inline __int_type
+       fetch_add(__int_type __i,
+ 		memory_order __m = memory_order_seq_cst) noexcept
+       { return __atomic_fetch_add(&_M_i, __i, __m); }
+ 
+-      __always_inline __int_type
++      __libitm_always_inline __int_type
+       fetch_add(__int_type __i,
+ 		memory_order __m = memory_order_seq_cst) volatile noexcept
+       { return __atomic_fetch_add(&_M_i, __i, __m); }
+ 
+-      __always_inline __int_type
++      __libitm_always_inline __int_type
+       fetch_sub(__int_type __i,
+ 		memory_order __m = memory_order_seq_cst) noexcept
+       { return __atomic_fetch_sub(&_M_i, __i, __m); }
+ 
+-      __always_inline __int_type
++      __libitm_always_inline __int_type
+       fetch_sub(__int_type __i,
+ 		memory_order __m = memory_order_seq_cst) volatile noexcept
+       { return __atomic_fetch_sub(&_M_i, __i, __m); }
+ 
+-      __always_inline __int_type
++      __libitm_always_inline __int_type
+       fetch_and(__int_type __i,
+ 		memory_order __m = memory_order_seq_cst) noexcept
+       { return __atomic_fetch_and(&_M_i, __i, __m); }
+ 
+-      __always_inline __int_type
++      __libitm_always_inline __int_type
+       fetch_and(__int_type __i,
+ 		memory_order __m = memory_order_seq_cst) volatile noexcept
+       { return __atomic_fetch_and(&_M_i, __i, __m); }
+ 
+-      __always_inline __int_type
++      __libitm_always_inline __int_type
+       fetch_or(__int_type __i,
+ 	       memory_order __m = memory_order_seq_cst) noexcept
+       { return __atomic_fetch_or(&_M_i, __i, __m); }
+ 
+-      __always_inline __int_type
++      __libitm_always_inline __int_type
+       fetch_or(__int_type __i,
+ 	       memory_order __m = memory_order_seq_cst) volatile noexcept
+       { return __atomic_fetch_or(&_M_i, __i, __m); }
+ 
+-      __always_inline __int_type
++      __libitm_always_inline __int_type
+       fetch_xor(__int_type __i,
+ 		memory_order __m = memory_order_seq_cst) noexcept
+       { return __atomic_fetch_xor(&_M_i, __i, __m); }
+ 
+-      __always_inline __int_type
++      __libitm_always_inline __int_type
+       fetch_xor(__int_type __i,
+ 		memory_order __m = memory_order_seq_cst) volatile noexcept
+       { return __atomic_fetch_xor(&_M_i, __i, __m); }
+@@ -733,7 +732,7 @@ namespace std // _GLIBCXX_VISIBILITY(default)
+       is_lock_free() const volatile noexcept
+       { return __atomic_is_lock_free (sizeof (_M_p), &_M_p); }
+ 
+-      __always_inline void
++      __libitm_always_inline void
+       store(__pointer_type __p,
+ 	    memory_order __m = memory_order_seq_cst) noexcept
+       {
+@@ -744,7 +743,7 @@ namespace std // _GLIBCXX_VISIBILITY(default)
+ 	__atomic_store_n(&_M_p, __p, __m);
+       }
+ 
+-      __always_inline void
++      __libitm_always_inline void
+       store(__pointer_type __p,
+ 	    memory_order __m = memory_order_seq_cst) volatile noexcept
+       {
+@@ -755,7 +754,7 @@ namespace std // _GLIBCXX_VISIBILITY(default)
+ 	__atomic_store_n(&_M_p, __p, __m);
+       }
+ 
+-      __always_inline __pointer_type
++      __libitm_always_inline __pointer_type
+       load(memory_order __m = memory_order_seq_cst) const noexcept
+       {
+ 	// __glibcxx_assert(__m != memory_order_release);
+@@ -764,7 +763,7 @@ namespace std // _GLIBCXX_VISIBILITY(default)
+ 	return __atomic_load_n(&_M_p, __m);
+       }
+ 
+-      __always_inline __pointer_type
++      __libitm_always_inline __pointer_type
+       load(memory_order __m = memory_order_seq_cst) const volatile noexcept
+       {
+ 	// __glibcxx_assert(__m != memory_order_release);
+@@ -773,21 +772,21 @@ namespace std // _GLIBCXX_VISIBILITY(default)
+ 	return __atomic_load_n(&_M_p, __m);
+       }
+ 
+-      __always_inline __pointer_type
++      __libitm_always_inline __pointer_type
+       exchange(__pointer_type __p,
+ 	       memory_order __m = memory_order_seq_cst) noexcept
+       {
+ 	return __atomic_exchange_n(&_M_p, __p, __m);
+       }
+ 
+-      __always_inline __pointer_type
++      __libitm_always_inline __pointer_type
+       exchange(__pointer_type __p,
+ 	       memory_order __m = memory_order_seq_cst) volatile noexcept
+       {
+ 	return __atomic_exchange_n(&_M_p, __p, __m);
+       }
+ 
+-      __always_inline bool
++      __libitm_always_inline bool
+       compare_exchange_strong(__pointer_type& __p1, __pointer_type __p2,
+ 			      memory_order __m1,
+ 			      memory_order __m2) noexcept
+@@ -799,7 +798,7 @@ namespace std // _GLIBCXX_VISIBILITY(default)
+ 	return __atomic_compare_exchange_n(&_M_p, &__p1, __p2, 0, __m1, __m2);
+       }
+ 
+-      __always_inline bool
++      __libitm_always_inline bool
+       compare_exchange_strong(__pointer_type& __p1, __pointer_type __p2,
+ 			      memory_order __m1,
+ 			      memory_order __m2) volatile noexcept
+@@ -811,22 +810,22 @@ namespace std // _GLIBCXX_VISIBILITY(default)
+ 	return __atomic_compare_exchange_n(&_M_p, &__p1, __p2, 0, __m1, __m2);
+       }
+ 
+-      __always_inline __pointer_type
++      __libitm_always_inline __pointer_type
+       fetch_add(ptrdiff_t __d,
+ 		memory_order __m = memory_order_seq_cst) noexcept
+       { return __atomic_fetch_add(&_M_p, __d, __m); }
+ 
+-      __always_inline __pointer_type
++      __libitm_always_inline __pointer_type
+       fetch_add(ptrdiff_t __d,
+ 		memory_order __m = memory_order_seq_cst) volatile noexcept
+       { return __atomic_fetch_add(&_M_p, __d, __m); }
+ 
+-      __always_inline __pointer_type
++      __libitm_always_inline __pointer_type
+       fetch_sub(ptrdiff_t __d,
+ 		memory_order __m = memory_order_seq_cst) noexcept
+       { return __atomic_fetch_sub(&_M_p, __d, __m); }
+ 
+-      __always_inline __pointer_type
++      __libitm_always_inline __pointer_type
+       fetch_sub(ptrdiff_t __d,
+ 		memory_order __m = memory_order_seq_cst) volatile noexcept
+       { return __atomic_fetch_sub(&_M_p, __d, __m); }
+@@ -870,67 +869,67 @@ namespace std // _GLIBCXX_VISIBILITY(default)
+     bool
+     is_lock_free() const volatile noexcept { return _M_base.is_lock_free(); }
+ 
+-    __always_inline void
++    __libitm_always_inline void
+     store(bool __i, memory_order __m = memory_order_seq_cst) noexcept
+     { _M_base.store(__i, __m); }
+ 
+-    __always_inline void
++    __libitm_always_inline void
+     store(bool __i, memory_order __m = memory_order_seq_cst) volatile noexcept
+     { _M_base.store(__i, __m); }
+ 
+-    __always_inline bool
++    __libitm_always_inline bool
+     load(memory_order __m = memory_order_seq_cst) const noexcept
+     { return _M_base.load(__m); }
+ 
+-    __always_inline bool
++    __libitm_always_inline bool
+     load(memory_order __m = memory_order_seq_cst) const volatile noexcept
+     { return _M_base.load(__m); }
+ 
+-    __always_inline bool
++    __libitm_always_inline bool
+     exchange(bool __i, memory_order __m = memory_order_seq_cst) noexcept
+     { return _M_base.exchange(__i, __m); }
+ 
+-    __always_inline bool
++    __libitm_always_inline bool
+     exchange(bool __i,
+ 	     memory_order __m = memory_order_seq_cst) volatile noexcept
+     { return _M_base.exchange(__i, __m); }
+ 
+-    __always_inline bool
++    __libitm_always_inline bool
+     compare_exchange_weak(bool& __i1, bool __i2, memory_order __m1,
+ 			  memory_order __m2) noexcept
+     { return _M_base.compare_exchange_weak(__i1, __i2, __m1, __m2); }
+ 
+-    __always_inline bool
++    __libitm_always_inline bool
+     compare_exchange_weak(bool& __i1, bool __i2, memory_order __m1,
+ 			  memory_order __m2) volatile noexcept
+     { return _M_base.compare_exchange_weak(__i1, __i2, __m1, __m2); }
+ 
+-    __always_inline bool
++    __libitm_always_inline bool
+     compare_exchange_weak(bool& __i1, bool __i2,
+ 			  memory_order __m = memory_order_seq_cst) noexcept
+     { return _M_base.compare_exchange_weak(__i1, __i2, __m); }
+ 
+-    __always_inline bool
++    __libitm_always_inline bool
+     compare_exchange_weak(bool& __i1, bool __i2,
+ 		     memory_order __m = memory_order_seq_cst) volatile noexcept
+     { return _M_base.compare_exchange_weak(__i1, __i2, __m); }
+ 
+-    __always_inline bool
++    __libitm_always_inline bool
+     compare_exchange_strong(bool& __i1, bool __i2, memory_order __m1,
+ 			    memory_order __m2) noexcept
+     { return _M_base.compare_exchange_strong(__i1, __i2, __m1, __m2); }
+ 
+-    __always_inline bool
++    __libitm_always_inline bool
+     compare_exchange_strong(bool& __i1, bool __i2, memory_order __m1,
+ 			    memory_order __m2) volatile noexcept
+     { return _M_base.compare_exchange_strong(__i1, __i2, __m1, __m2); }
+ 
+-    __always_inline bool
++    __libitm_always_inline bool
+     compare_exchange_strong(bool& __i1, bool __i2,
+ 			    memory_order __m = memory_order_seq_cst) noexcept
+     { return _M_base.compare_exchange_strong(__i1, __i2, __m); }
+ 
+-    __always_inline bool
++    __libitm_always_inline bool
+     compare_exchange_strong(bool& __i1, bool __i2,
+ 		    memory_order __m = memory_order_seq_cst) volatile noexcept
+     { return _M_base.compare_exchange_strong(__i1, __i2, __m); }
+@@ -980,11 +979,11 @@ namespace std // _GLIBCXX_VISIBILITY(default)
+       store(_Tp __i, memory_order _m = memory_order_seq_cst) noexcept
+       { __atomic_store(&_M_i, &__i, _m); }
+ 
+-      __always_inline void
++      __libitm_always_inline void
+       store(_Tp __i, memory_order _m = memory_order_seq_cst) volatile noexcept
+       { __atomic_store(&_M_i, &__i, _m); }
+ 
+-      __always_inline _Tp
++      __libitm_always_inline _Tp
+       load(memory_order _m = memory_order_seq_cst) const noexcept
+       { 
+         _Tp tmp;
+@@ -992,7 +991,7 @@ namespace std // _GLIBCXX_VISIBILITY(default)
+ 	return tmp;
+       }
+ 
+-      __always_inline _Tp
++      __libitm_always_inline _Tp
+       load(memory_order _m = memory_order_seq_cst) const volatile noexcept
+       { 
+         _Tp tmp;
+@@ -1000,7 +999,7 @@ namespace std // _GLIBCXX_VISIBILITY(default)
+ 	return tmp;
+       }
+ 
+-      __always_inline _Tp
++      __libitm_always_inline _Tp
+       exchange(_Tp __i, memory_order _m = memory_order_seq_cst) noexcept
+       { 
+         _Tp tmp;
+@@ -1008,7 +1007,7 @@ namespace std // _GLIBCXX_VISIBILITY(default)
+ 	return tmp;
+       }
+ 
+-      __always_inline _Tp
++      __libitm_always_inline _Tp
+       exchange(_Tp __i, 
+ 	       memory_order _m = memory_order_seq_cst) volatile noexcept
+       { 
+@@ -1017,50 +1016,50 @@ namespace std // _GLIBCXX_VISIBILITY(default)
+ 	return tmp;
+       }
+ 
+-      __always_inline bool
++      __libitm_always_inline bool
+       compare_exchange_weak(_Tp& __e, _Tp __i, memory_order __s, 
+ 			    memory_order __f) noexcept
+       {
+ 	return __atomic_compare_exchange(&_M_i, &__e, &__i, true, __s, __f); 
+       }
+ 
+-      __always_inline bool
++      __libitm_always_inline bool
+       compare_exchange_weak(_Tp& __e, _Tp __i, memory_order __s, 
+ 			    memory_order __f) volatile noexcept
+       {
+ 	return __atomic_compare_exchange(&_M_i, &__e, &__i, true, __s, __f); 
+       }
+ 
+-      __always_inline bool
++      __libitm_always_inline bool
+       compare_exchange_weak(_Tp& __e, _Tp __i,
+ 			    memory_order __m = memory_order_seq_cst) noexcept
+       { return compare_exchange_weak(__e, __i, __m, __m); }
+ 
+-      __always_inline bool
++      __libitm_always_inline bool
+       compare_exchange_weak(_Tp& __e, _Tp __i,
+ 		     memory_order __m = memory_order_seq_cst) volatile noexcept
+       { return compare_exchange_weak(__e, __i, __m, __m); }
+ 
+-      __always_inline bool
++      __libitm_always_inline bool
+       compare_exchange_strong(_Tp& __e, _Tp __i, memory_order __s, 
+ 			      memory_order __f) noexcept
+       {
+ 	return __atomic_compare_exchange(&_M_i, &__e, &__i, false, __s, __f); 
+       }
+ 
+-      __always_inline bool
++      __libitm_always_inline bool
+       compare_exchange_strong(_Tp& __e, _Tp __i, memory_order __s, 
+ 			      memory_order __f) volatile noexcept
+       {
+ 	return __atomic_compare_exchange(&_M_i, &__e, &__i, false, __s, __f); 
+       }
+ 
+-      __always_inline bool
++      __libitm_always_inline bool
+       compare_exchange_strong(_Tp& __e, _Tp __i,
+ 			       memory_order __m = memory_order_seq_cst) noexcept
+       { return compare_exchange_strong(__e, __i, __m, __m); }
+ 
+-      __always_inline bool
++      __libitm_always_inline bool
+       compare_exchange_strong(_Tp& __e, _Tp __i,
+ 		     memory_order __m = memory_order_seq_cst) volatile noexcept
+       { return compare_exchange_strong(__e, __i, __m, __m); }
+@@ -1153,46 +1152,46 @@ namespace std // _GLIBCXX_VISIBILITY(default)
+       is_lock_free() const volatile noexcept
+       { return _M_b.is_lock_free(); }
+ 
+-      __always_inline void
++      __libitm_always_inline void
+       store(__pointer_type __p,
+ 	    memory_order __m = memory_order_seq_cst) noexcept
+       { return _M_b.store(__p, __m); }
+ 
+-      __always_inline void
++      __libitm_always_inline void
+       store(__pointer_type __p,
+ 	    memory_order __m = memory_order_seq_cst) volatile noexcept
+       { return _M_b.store(__p, __m); }
+ 
+-      __always_inline __pointer_type
++      __libitm_always_inline __pointer_type
+       load(memory_order __m = memory_order_seq_cst) const noexcept
+       { return _M_b.load(__m); }
+ 
+-      __always_inline __pointer_type
++      __libitm_always_inline __pointer_type
+       load(memory_order __m = memory_order_seq_cst) const volatile noexcept
+       { return _M_b.load(__m); }
+ 
+-      __always_inline __pointer_type
++      __libitm_always_inline __pointer_type
+       exchange(__pointer_type __p,
+ 	       memory_order __m = memory_order_seq_cst) noexcept
+       { return _M_b.exchange(__p, __m); }
+ 
+-      __always_inline __pointer_type
++      __libitm_always_inline __pointer_type
+       exchange(__pointer_type __p,
+ 	       memory_order __m = memory_order_seq_cst) volatile noexcept
+       { return _M_b.exchange(__p, __m); }
+ 
+-      __always_inline bool
++      __libitm_always_inline bool
+       compare_exchange_weak(__pointer_type& __p1, __pointer_type __p2,
+ 			    memory_order __m1, memory_order __m2) noexcept
+       { return _M_b.compare_exchange_strong(__p1, __p2, __m1, __m2); }
+ 
+-      __always_inline bool
++      __libitm_always_inline bool
+       compare_exchange_weak(__pointer_type& __p1, __pointer_type __p2,
+ 			    memory_order __m1,
+ 			    memory_order __m2) volatile noexcept
+       { return _M_b.compare_exchange_strong(__p1, __p2, __m1, __m2); }
+ 
+-      __always_inline bool
++      __libitm_always_inline bool
+       compare_exchange_weak(__pointer_type& __p1, __pointer_type __p2,
+ 			    memory_order __m = memory_order_seq_cst) noexcept
+       {
+@@ -1200,7 +1199,7 @@ namespace std // _GLIBCXX_VISIBILITY(default)
+ 				     __calculate_memory_order(__m));
+       }
+ 
+-      __always_inline bool
++      __libitm_always_inline bool
+       compare_exchange_weak(__pointer_type& __p1, __pointer_type __p2,
+ 		    memory_order __m = memory_order_seq_cst) volatile noexcept
+       {
+@@ -1208,18 +1207,18 @@ namespace std // _GLIBCXX_VISIBILITY(default)
+ 				     __calculate_memory_order(__m));
+       }
+ 
+-      __always_inline bool
++      __libitm_always_inline bool
+       compare_exchange_strong(__pointer_type& __p1, __pointer_type __p2,
+ 			      memory_order __m1, memory_order __m2) noexcept
+       { return _M_b.compare_exchange_strong(__p1, __p2, __m1, __m2); }
+ 
+-      __always_inline bool
++      __libitm_always_inline bool
+       compare_exchange_strong(__pointer_type& __p1, __pointer_type __p2,
+ 			      memory_order __m1,
+ 			      memory_order __m2) volatile noexcept
+       { return _M_b.compare_exchange_strong(__p1, __p2, __m1, __m2); }
+ 
+-      __always_inline bool
++      __libitm_always_inline bool
+       compare_exchange_strong(__pointer_type& __p1, __pointer_type __p2,
+ 			      memory_order __m = memory_order_seq_cst) noexcept
+       {
+@@ -1227,7 +1226,7 @@ namespace std // _GLIBCXX_VISIBILITY(default)
+ 					    __calculate_memory_order(__m));
+       }
+ 
+-      __always_inline bool
++      __libitm_always_inline bool
+       compare_exchange_strong(__pointer_type& __p1, __pointer_type __p2,
+ 		    memory_order __m = memory_order_seq_cst) volatile noexcept
+       {
+@@ -1235,22 +1234,22 @@ namespace std // _GLIBCXX_VISIBILITY(default)
+ 					    __calculate_memory_order(__m));
+       }
+ 
+-      __always_inline __pointer_type
++      __libitm_always_inline __pointer_type
+       fetch_add(ptrdiff_t __d,
+ 		memory_order __m = memory_order_seq_cst) noexcept
+       { return _M_b.fetch_add(__d, __m); }
+ 
+-      __always_inline __pointer_type
++      __libitm_always_inline __pointer_type
+       fetch_add(ptrdiff_t __d,
+ 		memory_order __m = memory_order_seq_cst) volatile noexcept
+       { return _M_b.fetch_add(__d, __m); }
+ 
+-      __always_inline __pointer_type
++      __libitm_always_inline __pointer_type
+       fetch_sub(ptrdiff_t __d,
+ 		memory_order __m = memory_order_seq_cst) noexcept
+       { return _M_b.fetch_sub(__d, __m); }
+ 
+-      __always_inline __pointer_type
++      __libitm_always_inline __pointer_type
+       fetch_sub(ptrdiff_t __d,
+ 		memory_order __m = memory_order_seq_cst) volatile noexcept
+       { return _M_b.fetch_sub(__d, __m); }
+@@ -1544,98 +1543,98 @@ namespace std // _GLIBCXX_VISIBILITY(default)
+ 
+ 
+   // Function definitions, atomic_flag operations.
+-  inline __always_inline bool
++  inline __libitm_always_inline bool
+   atomic_flag_test_and_set_explicit(atomic_flag* __a,
+ 				    memory_order __m) noexcept
+   { return __a->test_and_set(__m); }
+ 
+-  inline __always_inline bool
++  inline __libitm_always_inline bool
+   atomic_flag_test_and_set_explicit(volatile atomic_flag* __a,
+ 				    memory_order __m) noexcept
+   { return __a->test_and_set(__m); }
+ 
+-  inline __always_inline void
++  inline __libitm_always_inline void
+   atomic_flag_clear_explicit(atomic_flag* __a, memory_order __m) noexcept
+   { __a->clear(__m); }
+ 
+-  inline __always_inline void
++  inline __libitm_always_inline void
+   atomic_flag_clear_explicit(volatile atomic_flag* __a,
+ 			     memory_order __m) noexcept
+   { __a->clear(__m); }
+ 
+-  inline __always_inline bool
++  inline __libitm_always_inline bool
+   atomic_flag_test_and_set(atomic_flag* __a) noexcept
+   { return atomic_flag_test_and_set_explicit(__a, memory_order_seq_cst); }
+ 
+-  inline __always_inline bool
++  inline __libitm_always_inline bool
+   atomic_flag_test_and_set(volatile atomic_flag* __a) noexcept
+   { return atomic_flag_test_and_set_explicit(__a, memory_order_seq_cst); }
+ 
+-  inline __always_inline void
++  inline __libitm_always_inline void
+   atomic_flag_clear(atomic_flag* __a) noexcept
+   { atomic_flag_clear_explicit(__a, memory_order_seq_cst); }
+ 
+-  inline __always_inline void
++  inline __libitm_always_inline void
+   atomic_flag_clear(volatile atomic_flag* __a) noexcept
+   { atomic_flag_clear_explicit(__a, memory_order_seq_cst); }
+ 
+ 
+   // Function templates generally applicable to atomic types.
+   template<typename _ITp>
+-    __always_inline bool
++    __libitm_always_inline bool
+     atomic_is_lock_free(const atomic<_ITp>* __a) noexcept
+     { return __a->is_lock_free(); }
+ 
+   template<typename _ITp>
+-    __always_inline bool
++    __libitm_always_inline bool
+     atomic_is_lock_free(const volatile atomic<_ITp>* __a) noexcept
+     { return __a->is_lock_free(); }
+ 
+   template<typename _ITp>
+-    __always_inline void
++    __libitm_always_inline void
+     atomic_init(atomic<_ITp>* __a, _ITp __i) noexcept;
+ 
+   template<typename _ITp>
+-    __always_inline void
++    __libitm_always_inline void
+     atomic_init(volatile atomic<_ITp>* __a, _ITp __i) noexcept;
+ 
+   template<typename _ITp>
+-    __always_inline void
++    __libitm_always_inline void
+     atomic_store_explicit(atomic<_ITp>* __a, _ITp __i,
+ 			  memory_order __m) noexcept
+     { __a->store(__i, __m); }
+ 
+   template<typename _ITp>
+-    __always_inline void
++    __libitm_always_inline void
+     atomic_store_explicit(volatile atomic<_ITp>* __a, _ITp __i,
+ 			  memory_order __m) noexcept
+     { __a->store(__i, __m); }
+ 
+   template<typename _ITp>
+-    __always_inline _ITp
++    __libitm_always_inline _ITp
+     atomic_load_explicit(const atomic<_ITp>* __a, memory_order __m) noexcept
+     { return __a->load(__m); }
+ 
+   template<typename _ITp>
+-    __always_inline _ITp
++    __libitm_always_inline _ITp
+     atomic_load_explicit(const volatile atomic<_ITp>* __a,
+ 			 memory_order __m) noexcept
+     { return __a->load(__m); }
+ 
+   template<typename _ITp>
+-    __always_inline _ITp
++    __libitm_always_inline _ITp
+     atomic_exchange_explicit(atomic<_ITp>* __a, _ITp __i,
+ 			     memory_order __m) noexcept
+     { return __a->exchange(__i, __m); }
+ 
+   template<typename _ITp>
+-    __always_inline _ITp
++    __libitm_always_inline _ITp
+     atomic_exchange_explicit(volatile atomic<_ITp>* __a, _ITp __i,
+ 			     memory_order __m) noexcept
+     { return __a->exchange(__i, __m); }
+ 
+   template<typename _ITp>
+-    __always_inline bool
++    __libitm_always_inline bool
+     atomic_compare_exchange_weak_explicit(atomic<_ITp>* __a,
+ 					  _ITp* __i1, _ITp __i2,
+ 					  memory_order __m1,
+@@ -1643,7 +1642,7 @@ namespace std // _GLIBCXX_VISIBILITY(default)
+     { return __a->compare_exchange_weak(*__i1, __i2, __m1, __m2); }
+ 
+   template<typename _ITp>
+-    __always_inline bool
++    __libitm_always_inline bool
+     atomic_compare_exchange_weak_explicit(volatile atomic<_ITp>* __a,
+ 					  _ITp* __i1, _ITp __i2,
+ 					  memory_order __m1,
+@@ -1651,7 +1650,7 @@ namespace std // _GLIBCXX_VISIBILITY(default)
+     { return __a->compare_exchange_weak(*__i1, __i2, __m1, __m2); }
+ 
+   template<typename _ITp>
+-    __always_inline bool
++    __libitm_always_inline bool
+     atomic_compare_exchange_strong_explicit(atomic<_ITp>* __a,
+ 					    _ITp* __i1, _ITp __i2,
+ 					    memory_order __m1,
+@@ -1659,7 +1658,7 @@ namespace std // _GLIBCXX_VISIBILITY(default)
+     { return __a->compare_exchange_strong(*__i1, __i2, __m1, __m2); }
+ 
+   template<typename _ITp>
+-    __always_inline bool
++    __libitm_always_inline bool
+     atomic_compare_exchange_strong_explicit(volatile atomic<_ITp>* __a,
+ 					    _ITp* __i1, _ITp __i2,
+ 					    memory_order __m1,
+@@ -1668,37 +1667,37 @@ namespace std // _GLIBCXX_VISIBILITY(default)
+ 
+ 
+   template<typename _ITp>
+-    __always_inline void
++    __libitm_always_inline void
+     atomic_store(atomic<_ITp>* __a, _ITp __i) noexcept
+     { atomic_store_explicit(__a, __i, memory_order_seq_cst); }
+ 
+   template<typename _ITp>
+-    __always_inline void
++    __libitm_always_inline void
+     atomic_store(volatile atomic<_ITp>* __a, _ITp __i) noexcept
+     { atomic_store_explicit(__a, __i, memory_order_seq_cst); }
+ 
+   template<typename _ITp>
+-    __always_inline _ITp
++    __libitm_always_inline _ITp
+     atomic_load(const atomic<_ITp>* __a) noexcept
+     { return atomic_load_explicit(__a, memory_order_seq_cst); }
+ 
+   template<typename _ITp>
+-    __always_inline _ITp
++    __libitm_always_inline _ITp
+     atomic_load(const volatile atomic<_ITp>* __a) noexcept
+     { return atomic_load_explicit(__a, memory_order_seq_cst); }
+ 
+   template<typename _ITp>
+-    __always_inline _ITp
++    __libitm_always_inline _ITp
+     atomic_exchange(atomic<_ITp>* __a, _ITp __i) noexcept
+     { return atomic_exchange_explicit(__a, __i, memory_order_seq_cst); }
+ 
+   template<typename _ITp>
+-    __always_inline _ITp
++    __libitm_always_inline _ITp
+     atomic_exchange(volatile atomic<_ITp>* __a, _ITp __i) noexcept
+     { return atomic_exchange_explicit(__a, __i, memory_order_seq_cst); }
+ 
+   template<typename _ITp>
+-    __always_inline bool
++    __libitm_always_inline bool
+     atomic_compare_exchange_weak(atomic<_ITp>* __a,
+ 				 _ITp* __i1, _ITp __i2) noexcept
+     {
+@@ -1708,7 +1707,7 @@ namespace std // _GLIBCXX_VISIBILITY(default)
+     }
+ 
+   template<typename _ITp>
+-    __always_inline bool
++    __libitm_always_inline bool
+     atomic_compare_exchange_weak(volatile atomic<_ITp>* __a,
+ 				 _ITp* __i1, _ITp __i2) noexcept
+     {
+@@ -1718,7 +1717,7 @@ namespace std // _GLIBCXX_VISIBILITY(default)
+     }
+ 
+   template<typename _ITp>
+-    __always_inline bool
++    __libitm_always_inline bool
+     atomic_compare_exchange_strong(atomic<_ITp>* __a,
+ 				   _ITp* __i1, _ITp __i2) noexcept
+     {
+@@ -1728,7 +1727,7 @@ namespace std // _GLIBCXX_VISIBILITY(default)
+     }
+ 
+   template<typename _ITp>
+-    __always_inline bool
++    __libitm_always_inline bool
+     atomic_compare_exchange_strong(volatile atomic<_ITp>* __a,
+ 				   _ITp* __i1, _ITp __i2) noexcept
+     {
+@@ -1742,158 +1741,158 @@ namespace std // _GLIBCXX_VISIBILITY(default)
+   // intergral types as specified in the standard, excluding address
+   // types.
+   template<typename _ITp>
+-    __always_inline _ITp
++    __libitm_always_inline _ITp
+     atomic_fetch_add_explicit(__atomic_base<_ITp>* __a, _ITp __i,
+ 			      memory_order __m) noexcept
+     { return __a->fetch_add(__i, __m); }
+ 
+   template<typename _ITp>
+-    __always_inline _ITp
++    __libitm_always_inline _ITp
+     atomic_fetch_add_explicit(volatile __atomic_base<_ITp>* __a, _ITp __i,
+ 			      memory_order __m) noexcept
+     { return __a->fetch_add(__i, __m); }
+ 
+   template<typename _ITp>
+-    __always_inline _ITp
++    __libitm_always_inline _ITp
+     atomic_fetch_sub_explicit(__atomic_base<_ITp>* __a, _ITp __i,
+ 			      memory_order __m) noexcept
+     { return __a->fetch_sub(__i, __m); }
+ 
+   template<typename _ITp>
+-    __always_inline _ITp
++    __libitm_always_inline _ITp
+     atomic_fetch_sub_explicit(volatile __atomic_base<_ITp>* __a, _ITp __i,
+ 			      memory_order __m) noexcept
+     { return __a->fetch_sub(__i, __m); }
+ 
+   template<typename _ITp>
+-    __always_inline _ITp
++    __libitm_always_inline _ITp
+     atomic_fetch_and_explicit(__atomic_base<_ITp>* __a, _ITp __i,
+ 			      memory_order __m) noexcept
+     { return __a->fetch_and(__i, __m); }
+ 
+   template<typename _ITp>
+-    __always_inline _ITp
++    __libitm_always_inline _ITp
+     atomic_fetch_and_explicit(volatile __atomic_base<_ITp>* __a, _ITp __i,
+ 			      memory_order __m) noexcept
+     { return __a->fetch_and(__i, __m); }
+ 
+   template<typename _ITp>
+-    __always_inline _ITp
++    __libitm_always_inline _ITp
+     atomic_fetch_or_explicit(__atomic_base<_ITp>* __a, _ITp __i,
+ 			     memory_order __m) noexcept
+     { return __a->fetch_or(__i, __m); }
+ 
+   template<typename _ITp>
+-    __always_inline _ITp
++    __libitm_always_inline _ITp
+     atomic_fetch_or_explicit(volatile __atomic_base<_ITp>* __a, _ITp __i,
+ 			     memory_order __m) noexcept
+     { return __a->fetch_or(__i, __m); }
+ 
+   template<typename _ITp>
+-    __always_inline _ITp
++    __libitm_always_inline _ITp
+     atomic_fetch_xor_explicit(__atomic_base<_ITp>* __a, _ITp __i,
+ 			      memory_order __m) noexcept
+     { return __a->fetch_xor(__i, __m); }
+ 
+   template<typename _ITp>
+-    __always_inline _ITp
++    __libitm_always_inline _ITp
+     atomic_fetch_xor_explicit(volatile __atomic_base<_ITp>* __a, _ITp __i,
+ 			      memory_order __m) noexcept
+     { return __a->fetch_xor(__i, __m); }
+ 
+   template<typename _ITp>
+-    __always_inline _ITp
++    __libitm_always_inline _ITp
+     atomic_fetch_add(__atomic_base<_ITp>* __a, _ITp __i) noexcept
+     { return atomic_fetch_add_explicit(__a, __i, memory_order_seq_cst); }
+ 
+   template<typename _ITp>
+-    __always_inline _ITp
++    __libitm_always_inline _ITp
+     atomic_fetch_add(volatile __atomic_base<_ITp>* __a, _ITp __i) noexcept
+     { return atomic_fetch_add_explicit(__a, __i, memory_order_seq_cst); }
+ 
+   template<typename _ITp>
+-    __always_inline _ITp
++    __libitm_always_inline _ITp
+     atomic_fetch_sub(__atomic_base<_ITp>* __a, _ITp __i) noexcept
+     { return atomic_fetch_sub_explicit(__a, __i, memory_order_seq_cst); }
+ 
+   template<typename _ITp>
+-    __always_inline _ITp
++    __libitm_always_inline _ITp
+     atomic_fetch_sub(volatile __atomic_base<_ITp>* __a, _ITp __i) noexcept
+     { return atomic_fetch_sub_explicit(__a, __i, memory_order_seq_cst); }
+ 
+   template<typename _ITp>
+-    __always_inline _ITp
++    __libitm_always_inline _ITp
+     atomic_fetch_and(__atomic_base<_ITp>* __a, _ITp __i) noexcept
+     { return atomic_fetch_and_explicit(__a, __i, memory_order_seq_cst); }
+ 
+   template<typename _ITp>
+-    __always_inline _ITp
++    __libitm_always_inline _ITp
+     atomic_fetch_and(volatile __atomic_base<_ITp>* __a, _ITp __i) noexcept
+     { return atomic_fetch_and_explicit(__a, __i, memory_order_seq_cst); }
+ 
+   template<typename _ITp>
+-    __always_inline _ITp
++    __libitm_always_inline _ITp
+     atomic_fetch_or(__atomic_base<_ITp>* __a, _ITp __i) noexcept
+     { return atomic_fetch_or_explicit(__a, __i, memory_order_seq_cst); }
+ 
+   template<typename _ITp>
+-    __always_inline _ITp
++    __libitm_always_inline _ITp
+     atomic_fetch_or(volatile __atomic_base<_ITp>* __a, _ITp __i) noexcept
+     { return atomic_fetch_or_explicit(__a, __i, memory_order_seq_cst); }
+ 
+   template<typename _ITp>
+-    __always_inline _ITp
++    __libitm_always_inline _ITp
+     atomic_fetch_xor(__atomic_base<_ITp>* __a, _ITp __i) noexcept
+     { return atomic_fetch_xor_explicit(__a, __i, memory_order_seq_cst); }
+ 
+   template<typename _ITp>
+-    __always_inline _ITp
++    __libitm_always_inline _ITp
+     atomic_fetch_xor(volatile __atomic_base<_ITp>* __a, _ITp __i) noexcept
+     { return atomic_fetch_xor_explicit(__a, __i, memory_order_seq_cst); }
+ 
+ 
+   // Partial specializations for pointers.
+   template<typename _ITp>
+-    __always_inline _ITp*
++    __libitm_always_inline _ITp*
+     atomic_fetch_add_explicit(atomic<_ITp*>* __a, ptrdiff_t __d,
+ 			      memory_order __m) noexcept
+     { return __a->fetch_add(__d, __m); }
+ 
+   template<typename _ITp>
+-    __always_inline _ITp*
++    __libitm_always_inline _ITp*
+     atomic_fetch_add_explicit(volatile atomic<_ITp*>* __a, ptrdiff_t __d,
+ 			      memory_order __m) noexcept
+     { return __a->fetch_add(__d, __m); }
+ 
+   template<typename _ITp>
+-    __always_inline _ITp*
++    __libitm_always_inline _ITp*
+     atomic_fetch_add(volatile atomic<_ITp*>* __a, ptrdiff_t __d) noexcept
+     { return __a->fetch_add(__d); }
+ 
+   template<typename _ITp>
+-    __always_inline _ITp*
++    __libitm_always_inline _ITp*
+     atomic_fetch_add(atomic<_ITp*>* __a, ptrdiff_t __d) noexcept
+     { return __a->fetch_add(__d); }
+ 
+   template<typename _ITp>
+-    __always_inline _ITp*
++    __libitm_always_inline _ITp*
+     atomic_fetch_sub_explicit(volatile atomic<_ITp*>* __a,
+ 			      ptrdiff_t __d, memory_order __m) noexcept
+     { return __a->fetch_sub(__d, __m); }
+ 
+   template<typename _ITp>
+-    __always_inline _ITp*
++    __libitm_always_inline _ITp*
+     atomic_fetch_sub_explicit(atomic<_ITp*>* __a, ptrdiff_t __d,
+ 			      memory_order __m) noexcept
+     { return __a->fetch_sub(__d, __m); }
+ 
+   template<typename _ITp>
+-    __always_inline _ITp*
++    __libitm_always_inline _ITp*
+     atomic_fetch_sub(volatile atomic<_ITp*>* __a, ptrdiff_t __d) noexcept
+     { return __a->fetch_sub(__d); }
+ 
+   template<typename _ITp>
+-    __always_inline _ITp*
++    __libitm_always_inline _ITp*
+     atomic_fetch_sub(atomic<_ITp*>* __a, ptrdiff_t __d) noexcept
+     { return __a->fetch_sub(__d); }
+   // @} group atomics
+-- 
+2.19.2
+


### PR DESCRIPTION

*  Jan 2, 2019
Rebase patches to make 9980 bisectable.

*  Jan 2, 2019
Fix scheduling related assert when wal-peer is deleted with pending
tx buffers (bug 54, and others)

*  Jan 7, 2019:
Fix specifying retransmits for AMPDU frames.  It was previously ignored
since it is a 'software' retransmit instead of a hardware retransmit.

*  Jan 9, 2019
Fix potential way to get zero rates selected (and then assert)

*  Jan 18, 2019
pfsched has specific work-around to just return if we find invalid flags AND
if we are in an out-of-order situation.  Maybe this is last of the pfsched
related issues (bug 54 and similar).

*  Jan 24, 2019
The rcSibUpdate method can be called concurrently with IRQ tx-completion callback,
and that could potentially allow the tx-completion callback to see invalid state
and assert or otherwise mess up the rate-ctrl logic.  So, disable IRQs in
rcSibUpdate to prevent this.  Related to bug 58.

*  Jan 28, 2019
Ensure that cached config is applied to ratectrl objects when fetched from
the cache.  This should fix part of bug 58.

*  Jan 28, 2019
Ensure that ratectrl objects from cachemgr are always initialized.  This fixes
another part of bug 58.

*  Jan 30, 2019
Better use of temporary rate-ctrl object.  Make sure it is initialized, simplify
code path.  This finishes up porting forward similar changes I made for wave-1
firmware long ago, and fixes another potential way to hit bug-58 issues.

*  Jan 30, 2019
Cachemgr did not have a callback for when memory was logically freed.  This means
that peers could keep stale references to rate-ctrl objects that were in process
of being DMA'd into to load a different peer's rate-ctrl state.  This was causing
the bugcheck logic to fail early and often, and I suspect it might be a root cause
of bug 58 as well.  The fix is to add a callback and set any 'deleted' memory references
to NULL so that we cannot access it accidentally.  Thanks to excellent logs and patience
from the bug-58 reporter!

Signed-off-by: Koen Vandeputte <koen.vandeputte@ncentric.com>