### PR TITLE
build: qsdk-ipq-*: include dtc in PATH before calling mkimage

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -297,14 +297,14 @@ endef
 define Build/qsdk-ipq-factory-nand
 	$(TOPDIR)/scripts/mkits-qsdk-ipq-image.sh \
 		$@.its ubi $@
-	mkimage -f $@.its $@.new
+	PATH=$(LINUX_DIR)/scripts/dtc:$(PATH) mkimage -f $@.its $@.new
 	@mv $@.new $@
 endef
 
 define Build/qsdk-ipq-factory-nor
 	$(TOPDIR)/scripts/mkits-qsdk-ipq-image.sh \
 		$@.its hlos $(IMAGE_KERNEL) rootfs $(IMAGE_ROOTFS)
-	mkimage -f $@.its $@.new
+	PATH=$(LINUX_DIR)/scripts/dtc:$(PATH) mkimage -f $@.its $@.new
 	@mv $@.new $@
 endef
 


### PR DESCRIPTION
Use 'dtc' from kernel sources instead of relying on host tool.

Fixes: bf4630e5adb4 ("build: add helpers for generating QSDK sysupgrade compatible images")
Signed-off-by: Piotr Dymacz <pepe2k@gmail.com>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
