### PR TITLE
tools/mkimage: use http download server (fixes FS#2052)

### DIFF
--- a/tools/mkimage/Makefile
+++ b/tools/mkimage/Makefile
@@ -10,9 +10,7 @@ PKG_NAME:=mkimage
 PKG_VERSION:=2018.03
 
 PKG_SOURCE:=u-boot-$(PKG_VERSION).tar.bz2
-PKG_SOURCE_URL:=\
-	http://mirror2.openwrt.org/sources \
-	ftp://ftp.denx.de/pub/u-boot
+PKG_SOURCE_URL:=http://ftp.denx.de/pub/u-boot
 PKG_HASH:=7e7477534409d5368eb1371ffde6820f0f79780a1a1f676161c48442cb303dfd
 
 HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/u-boot-$(PKG_VERSION)


### PR DESCRIPTION
Fixes timeouts with trying to access the FTP site.
Also remove mirror2.openwrt.org, which does not keep current tarballs

Signed-off-by: Felix Fietkau <nbd@nbd.name>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
