### PR TITLE
scripts/qemustart: fix usage with networking support

### DIFF
--- a/scripts/qemustart
+++ b/scripts/qemustart
@@ -74,7 +74,7 @@ check_setup_() {
 }
 
 check_setup() {
-	[ -z $o_nonetwork ] || return 0
+	[ -z "$o_nonetwork" ] || return 0
 	check_setup_ || {
 		__errmsg "please check the script content to see the environment requirement"
 		return 1
@@ -187,7 +187,7 @@ start_qemu_armvirt() {
 		)
 	}
 
-	[ -n $o_nonetwork ] || {
+	[ -n "$o_nonetwork" ] || {
 		o_qemu_extra+=( \
 			"-netdev" "bridge,id=lan,br=$BR_LAN,helper=$HELPER" \
 			    "-device" "virtio-net-pci,id=devlan,netdev=lan,mac=$MAC_LAN" \
@@ -229,7 +229,7 @@ start_qemu_malta() {
 	# NOTE: order of wan, lan -device arguments matters as it will affect which
 	# one will be actually used as the wan, lan network interface inside the
 	# guest machine
-	[ -n $o_nonetwork ] || {
+	[ -n "$o_nonetwork" ] || {
 		o_qemu_extra+=( \
 			"-netdev" "bridge,id=wan,br=$BR_WAN,helper=$HELPER" "-device" \
 			    "virtio-net-pci,id=devwan,netdev=wan,mac=$MAC_WAN" \
@@ -276,7 +276,7 @@ start_qemu_x86() {
 	    )
 	}
 
-	[ -n $o_nonetwork ] || {
+	[ -n "$o_nonetwork" ] || {
 		o_qemu_extra+=( \
 			"-netdev" "bridge,id=lan,br=$BR_LAN,helper=$HELPER" \
 			    "-device" "virtio-net-pci,id=devlan,netdev=lan,mac=$MAC_LAN" \


### PR DESCRIPTION
Commit 8bf500eb79 added support for qemu usage without networking
support but broke networking support as -n and -z do not work with
unquoted argument; fix this by quoting the arguments.

Fixes 8bf500eb79

Signed-off-by: Hans Dedecker <dedeckeh@gmail.com>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
