### PR TITLE
kernel: fix regression on 4.19 with 613-netfilter_optional_tcp_window…

### DIFF
--- a/target/linux/generic/pending-4.19/613-netfilter_optional_tcp_window_check.patch
+++ b/target/linux/generic/pending-4.19/613-netfilter_optional_tcp_window_check.patch
@@ -28,6 +28,15 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	/*
  	 * Get the required data from the packet.
  	 */
+@@ -1057,7 +1063,7 @@ static int tcp_packet(struct nf_conn *ct
+ 		 IP_CT_TCP_FLAG_DATA_UNACKNOWLEDGED &&
+ 		 timeouts[new_state] > timeouts[TCP_CONNTRACK_UNACK])
+ 		timeout = timeouts[TCP_CONNTRACK_UNACK];
+-	else if (ct->proto.tcp.last_win == 0 &&
++	else if (!nf_ct_tcp_no_window_check && ct->proto.tcp.last_win == 0 &&
+ 		 timeouts[new_state] > timeouts[TCP_CONNTRACK_RETRANS])
+ 		timeout = timeouts[TCP_CONNTRACK_RETRANS];
+ 	else
 @@ -1506,6 +1512,13 @@ static struct ctl_table tcp_sysctl_table
  		.mode		= 0644,
  		.proc_handler	= proc_dointvec,


### PR DESCRIPTION
…_check.patch (FS#2253)

Since ct->proto.tcp.last_win isn't updated when nf_ct_tcp_no_window_check is
enabled, the retransmission timeout check needs to be bypassed.

Based on patch by Rob Mosher

Signed-off-by: Felix Fietkau <nbd@nbd.name>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
