### PR TITLE
libroxml: bump to the 3.0.1 version

### DIFF
--- a/package/libs/libroxml/Makefile
+++ b/package/libs/libroxml/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libroxml
-PKG_VERSION:=2.3.0
-PKG_RELEASE:=3
+PKG_VERSION:=3.0.1
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://download.libroxml.net/pool/v2.x
-PKG_HASH:=1da8f20b530eba4409f2b217587d2f1281ff5d9ba45b24aeac71b94c6c621b78
+PKG_SOURCE_URL:=http://download.libroxml.net/pool/v3.x
+PKG_HASH:=b55fd616a2be4e9747173b8dfa4bbab64f5ddfafd7d7a529aa91ab7755bc0ce6
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 
 PKG_INSTALL:=1
@@ -27,7 +27,7 @@ define Package/libroxml
   CATEGORY:=Libraries
   TITLE:=Minimum, easy-to-use, C implementation for xml file parsing
   URL:=http://www.libroxml.net/
-  ABI_VERSION:=0
+  ABI_VERSION:=3.0.1
 endef
 
 CONFIGURE_ARGS += \


### PR DESCRIPTION
Some of changes:
* Support for local-name()
* General refactoring
* Better parsing performance
* Fix possible buffer overflow & memleak
* Validation checks
* More commit functions (file, buffer, fd)

Signed-off-by: Rafał Miłecki <rafal@milecki.pl>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
