### PR TITLE
procd: add procd_running() helper for checking running state

### DIFF
--- a/package/system/procd/Makefile
+++ b/package/system/procd/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=procd
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/procd.git

--- a/package/system/procd/files/procd.sh
+++ b/package/system/procd/files/procd.sh
@@ -30,6 +30,9 @@
 # procd_close_instance():
 #   Complete the instance being prepared
 #
+# procd_running(service, [instance]):
+#   Checks if service/instance is currently running
+#
 # procd_kill(service, [instance]):
 #   Kill a service instance (or all instances)
 #
@@ -400,6 +403,18 @@ _procd_add_instance() {
 	_procd_open_instance
 	_procd_set_param command "$@"
 	_procd_close_instance
+}
+
+procd_running() {
+	local service="$1"
+	local instance="${2:-instance1}"
+	local running
+
+	json_init
+	json_add_string name "$service"
+	running=$(_procd_ubus_call list | jsonfilter -e "@.$service.instances.${instance}.running")
+
+	[ "$running" = "true" ]
 }
 
 _procd_kill() {


### PR DESCRIPTION
This should be helpful for implementing service_running() in procd init
scripts.

Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
Acked-by: John Crispin <john@phrozen.org>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
